### PR TITLE
Updated syntax to Swift 3.0 (except deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# tictactoe
+# TicTacToe iOS App
+
+## Overview
+This is a simple TicTacToe game developed for iOS using Swift. The app allows users to play TicTacToe against each other or against a computer.
+
+## Features
+- **Two Player Mode:** Play against a friend.
+- **Single Player Mode:** Play against the computer.
+- **Score Tracking:** Keep track of wins.
+- **User-friendly Interface:** Easy to navigate.
+
+## Architecture
+The app is built using the Model-View-Controller (MVC) design pattern. The key components include:
+- **Model:** Represents the game state and logic.
+- **View:** Displays the game board and user interface.
+- **Controller:** Manages user interactions and game flow.
+
+## Gameplay
+Players take turns marking a cell in a 3x3 grid. The first player to get three in a row (horizontally, vertically, or diagonally) wins the game. If all cells are filled without any player achieving three in a row, the game ends in a draw.
+
+## Requirements
+- **Xcode**: Latest version
+- **Swift**: Latest version (Swift 6 or later)
+- **iOS Deployment Target**: iOS 14.0 or later
+
+## Installation
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/peternicholls/tictactoe.git
+   ```
+2. Open the project in Xcode.
+3. Build and run the project.
+
+## Modern Swift 6 Implementation
+This app utilizes the latest Swift 6 features and best practices such as:
+- **Concurrency:** Using async/await for smoother asynchronous tasks.
+- **SwiftUI:** Leveraging the SwiftUI framework for building user interfaces.
+- **Combine Framework:** For handling events and data flow reactive way.
+
+Enjoy playing TicTacToe!

--- a/TicTacToe.xcodeproj/project.pbxproj
+++ b/TicTacToe.xcodeproj/project.pbxproj
@@ -104,11 +104,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = GittieLabs;
 				TargetAttributes = {
 					CDCF28A01D22036D0068FDFA = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -193,8 +194,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -239,8 +242,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -259,6 +264,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -272,6 +278,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gittielabs.TicTacToe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -283,6 +290,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gittielabs.TicTacToe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/TicTacToe/AIStrategy.swift
+++ b/TicTacToe/AIStrategy.swift
@@ -10,15 +10,15 @@ import GameplayKit
 import Foundation
 
 enum PlayerType: Int{
-    case X
-    case O
-    case None
+    case x
+    case o
+    case none
 }
 
 enum GameState: Int{
-    case Winner
-    case Draw
-    case Playing
+    case winner
+    case draw
+    case playing
 }
 
 struct BoardCell{
@@ -53,11 +53,11 @@ class Move: NSObject, GKGameModelUpdate{
 
 @objc(Board)
 class Board: NSObject, NSCopying, GKGameModel{
-    private let _players: [GKGameModelPlayer] = [Player(player: 0), Player(player: 1)]
-    private var currentPlayer: GKGameModelPlayer?
-    private var board: [BoardCell]
-    private var currentScoreForPlayerOne: Int
-    private var currentScoreForPlayerTwo: Int
+    fileprivate let _players: [GKGameModelPlayer] = [Player(player: 0), Player(player: 1)]
+    fileprivate var currentPlayer: GKGameModelPlayer?
+    fileprivate var board: [BoardCell]
+    fileprivate var currentScoreForPlayerOne: Int
+    fileprivate var currentScoreForPlayerTwo: Int
     
     func isPlayerOne()->Bool{
         return currentPlayer?.playerId == _players[0].playerId
@@ -71,7 +71,7 @@ class Board: NSObject, NSCopying, GKGameModel{
         return _players[1]
     }
     
-    func setActivePlayer(player: GKGameModelPlayer){
+    func setActivePlayer(_ player: GKGameModelPlayer){
         currentPlayer = player
     }
     
@@ -91,22 +91,22 @@ class Board: NSObject, NSCopying, GKGameModel{
         currentPlayer = _players[1]
     }
     
-    func getElementAtBoardLocation(index:Int)->BoardCell{
+    func getElementAtBoardLocation(_ index:Int)->BoardCell{
         assert(index < board.count, "Location on board must be less than total elements in array")
         return board[index]
     }
     
-    func addPlayerValueAtBoardLocation(index: Int, value: PlayerType){
+    func addPlayerValueAtBoardLocation(_ index: Int, value: PlayerType){
         assert(index < board.count, "Location on board must be less than total elements in array")
         board[index].value = value
     }
     
-    @objc func isPlayerOne(player: GKGameModelPlayer)->Bool{
+    @objc func isPlayerOne(_ player: GKGameModelPlayer)->Bool{
         return player.playerId == _players[0].playerId
     }
     
     
-    @objc func copyWithZone(zone: NSZone) -> AnyObject{
+    @objc func copy(with zone: NSZone?) -> Any{
         let copy = Board()
         copy.setGameModel(self)
         return copy
@@ -149,17 +149,17 @@ class Board: NSObject, NSCopying, GKGameModel{
         currentPlayer = currentPlayer?.playerId == _players[0].playerId ? _players[1] : _players[0]
     }
     
-    func setGameModel(gameModel: GKGameModel) {
+    func setGameModel(_ gameModel: GKGameModel) {
         if let board = gameModel as? Board{
             self.currentPlayer = board.currentPlayer
             self.board = Array(board.board)
         }
     }
     
-    func gameModelUpdatesForPlayer(player: GKGameModelPlayer) -> [GKGameModelUpdate]? {
+    func gameModelUpdates(for player: GKGameModelPlayer) -> [GKGameModelUpdate]? {
         var moves:[GKGameModelUpdate] = []
-        for (index, _) in self.board.enumerate(){
-            if self.board[index].value == .None{
+        for (index, _) in self.board.enumerated(){
+            if self.board[index].value == .none{
                 moves.append(Move(cell: index))
             }
         }
@@ -167,43 +167,43 @@ class Board: NSObject, NSCopying, GKGameModel{
         return moves
     }
     
-    func unapplyGameModelUpdate(gameModelUpdate: GKGameModelUpdate) {
+    func unapplyGameModelUpdate(_ gameModelUpdate: GKGameModelUpdate) {
         let move = gameModelUpdate as! Move
-        self.board[move.cell].value = .None
+        self.board[move.cell].value = .none
         self.togglePlayer()
     }
     
-    func applyGameModelUpdate(gameModelUpdate: GKGameModelUpdate) {
+    func apply(_ gameModelUpdate: GKGameModelUpdate) {
         let move = gameModelUpdate as! Move
-        self.board[move.cell].value = isPlayerOne() ? .X : .O
+        self.board[move.cell].value = isPlayerOne() ? .x : .o
         self.togglePlayer()
     
     }
 
-    func getPlayerAtBoardCell(gridCoord: BoardCell)->GKGameModelPlayer?{
-        return gridCoord.value == .X ? self.players?.first: self.players?.last
+    func getPlayerAtBoardCell(_ gridCoord: BoardCell)->GKGameModelPlayer?{
+        return gridCoord.value == .x ? self.players?.first: self.players?.last
     }
     
-    func isWinForPlayer(player: GKGameModelPlayer) -> Bool {
+    func isWin(for player: GKGameModelPlayer) -> Bool {
         let (state, winner) = determineIfWinner()
-        if state == .Winner && winner?.playerId == player.playerId{
+        if state == .winner && winner?.playerId == player.playerId{
             return true
         }
         
         return false
     }
     
-    func isLossForPlayer(player: GKGameModelPlayer) -> Bool {
+    func isLoss(for player: GKGameModelPlayer) -> Bool {
         let (state, winner) = determineIfWinner()
-        if state == .Winner && winner?.playerId != player.playerId{
+        if state == .winner && winner?.playerId != player.playerId{
             return true
         }
         
         return false
     }
     
-    func scoreForPlayer(player: GKGameModelPlayer) -> Int {
-        if isWinForPlayer(player){
+    func score(for player: GKGameModelPlayer) -> Int {
+        if isWin(for: player){
             if isPlayerOne(player){
                 currentScoreForPlayerOne += 4
                 return currentScoreForPlayerOne
@@ -214,7 +214,7 @@ class Board: NSObject, NSCopying, GKGameModel{
             }
         }
         
-        if isLossForPlayer(player){
+        if isLoss(for: player){
             return 0
         }
         
@@ -254,11 +254,11 @@ class Board: NSObject, NSCopying, GKGameModel{
         }
     }
     
-    func isOneMoveAwayFromWinning(player: GKGameModelPlayer)->Bool {
+    func isOneMoveAwayFromWinning(_ player: GKGameModelPlayer)->Bool {
         
         let row_diagonal_Checker = {(row:ArraySlice<BoardCell>, playerCell: PlayerType)->Bool in
             let numofPlayerTypes = row.filter{$0.value == playerCell}
-            let containsBlankCells = row.filter{$0.value == .None}
+            let containsBlankCells = row.filter{$0.value == .none}
         
             if containsBlankCells.count == 0{
                 return false
@@ -272,7 +272,7 @@ class Board: NSObject, NSCopying, GKGameModel{
         
         // check the rows for two in a row
         let row1 = board[0...2]
-        let playerCell: PlayerType = isPlayerOne(player) ? .X : .O
+        let playerCell: PlayerType = isPlayerOne(player) ? .x : .o
         let row2 = board[3...5]
         let row3 = board[6...8]
         
@@ -338,56 +338,56 @@ class Board: NSObject, NSCopying, GKGameModel{
     
     func determineIfWinner()->(GameState, GKGameModelPlayer?){
         // check rows for a winner
-        if board[0].value != .None && (board[0].value == board[1].value && board[0].value == board[2].value){
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[0]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[0].value != .none && (board[0].value == board[1].value && board[0].value == board[2].value){
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[0]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
-        if board[3].value != .None && (board[3].value == board[4].value && board[3].value == board[5].value){
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[3]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[3].value != .none && (board[3].value == board[4].value && board[3].value == board[5].value){
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[3]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
-        if board[6].value != .None && (board[6].value == board[7].value && board[6].value == board[8].value) {
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[6]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[6].value != .none && (board[6].value == board[7].value && board[6].value == board[8].value) {
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[6]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
         // check columns for a winner
-        if board[0].value != .None && (board[0].value == board[3].value && board[3].value == board[6].value){
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[0]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[0].value != .none && (board[0].value == board[3].value && board[3].value == board[6].value){
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[0]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
-        if board[1].value != .None && (board[1].value == board[4].value && board[4].value == board[7].value){
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[1]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[1].value != .none && (board[1].value == board[4].value && board[4].value == board[7].value){
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[1]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
-        if board[2].value != .None && (board[2].value == board[5].value && board[5].value == board[8].value){
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[2]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[2].value != .none && (board[2].value == board[5].value && board[5].value == board[8].value){
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[2]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
         // check diagonals for a winner
-        if board[0].value != .None && (board[0].value == board[4].value && board[4].value == board[8].value){
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[0]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[0].value != .none && (board[0].value == board[4].value && board[4].value == board[8].value){
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[0]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
-        if board[2].value != .None && (board[2].value == board[4].value && board[4].value == board[6].value){
-            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[2]) else{ return (.Draw, nil)}
-            return (.Winner, winner)
+        if board[2].value != .none && (board[2].value == board[4].value && board[4].value == board[6].value){
+            guard let winner: GKGameModelPlayer = getPlayerAtBoardCell(board[2]) else{ return (.draw, nil)}
+            return (.winner, winner)
         }
         
         let foundEmptyCells: [BoardCell] = board.filter{ (gridCoord) -> Bool in
-            return gridCoord.value == .None
+            return gridCoord.value == .none
         }
         
         if foundEmptyCells.isEmpty{
-            return (.Draw, nil)
+            return (.draw, nil)
         }
         
-        return (.Playing, nil)
+        return (.playing, nil)
     }
 }

--- a/TicTacToe/AppDelegate.swift
+++ b/TicTacToe/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/TicTacToe/AppDelegate.swift
+++ b/TicTacToe/AppDelegate.swift
@@ -8,13 +8,13 @@
 
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/TicTacToe/GameScene.swift
+++ b/TicTacToe/GameScene.swift
@@ -14,23 +14,23 @@ class GameScene: SKScene {
     var stateMachine: GKStateMachine!
     var ai: GKMinmaxStrategist!
     
-    override func didMoveToView(view: SKView) {
+    override func didMove(to view: SKView) {
         /* Setup your scene here */
-        self.enumerateChildNodesWithName("//grid*") { (node, stop) in
+        self.enumerateChildNodes(withName: "//grid*") { (node, stop) in
             if let node = node as? SKSpriteNode{
-                node.color = UIColor.clearColor()
+                node.color = UIColor.clear
             }
         }
         
-        let top_left: BoardCell  = BoardCell(value: .None, node: "//*top_left")
-        let top_middle: BoardCell = BoardCell(value: .None, node: "//*top_middle")
-        let top_right: BoardCell = BoardCell(value: .None, node: "//*top_right")
-        let middle_left: BoardCell = BoardCell(value: .None, node: "//*middle_left")
-        let center: BoardCell = BoardCell(value: .None, node: "//*center")
-        let middle_right: BoardCell = BoardCell(value: .None, node: "//*middle_right")
-        let bottom_left: BoardCell = BoardCell(value: .None, node: "//*bottom_left")
-        let bottom_middle: BoardCell = BoardCell(value: .None, node: "//*bottom_middle")
-        let bottom_right: BoardCell = BoardCell(value: .None, node: "//*bottom_right")
+        let top_left: BoardCell  = BoardCell(value: .none, node: "//*top_left")
+        let top_middle: BoardCell = BoardCell(value: .none, node: "//*top_middle")
+        let top_right: BoardCell = BoardCell(value: .none, node: "//*top_right")
+        let middle_left: BoardCell = BoardCell(value: .none, node: "//*middle_left")
+        let center: BoardCell = BoardCell(value: .none, node: "//*center")
+        let middle_right: BoardCell = BoardCell(value: .none, node: "//*middle_right")
+        let bottom_left: BoardCell = BoardCell(value: .none, node: "//*bottom_left")
+        let bottom_middle: BoardCell = BoardCell(value: .none, node: "//*bottom_middle")
+        let bottom_right: BoardCell = BoardCell(value: .none, node: "//*bottom_right")
         
         let board = [top_left, top_middle, top_right, middle_left, center, middle_right, bottom_left, bottom_middle, bottom_right]
         
@@ -45,19 +45,19 @@ class GameScene: SKScene {
         let endGameState = EndGameState(scene: self)
         
         stateMachine = GKStateMachine(states: [beginGameState, activeGameState, endGameState])
-        stateMachine.enterState(StartGameState.self)
+        stateMachine.enter(StartGameState.self)
         
     }
     
-    override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {        
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {        
         for touch in touches {
-            let location = touch.locationInNode(self)
-            let selectedNode = self.nodeAtPoint(location)
+            let location = touch.location(in: self)
+            let selectedNode = self.atPoint(location)
             var node: SKSpriteNode
             
             if let name = selectedNode.name {
                 if name == "Reset" || name == "reset_label"{
-                    self.stateMachine.enterState(StartGameState.self)
+                    self.stateMachine.enter(StartGameState.self)
                     return
                 }
             }
@@ -75,20 +75,20 @@ class GameScene: SKScene {
             }
             
             for i in 0...8{
-                guard let cellNode: SKSpriteNode = self.childNodeWithName(gameBoard.getElementAtBoardLocation(i).node) as? SKSpriteNode else{
+                guard let cellNode: SKSpriteNode = self.childNode(withName: gameBoard.getElementAtBoardLocation(i).node) as? SKSpriteNode else{
                     return
                 }
                 if selectedNode.name == cellNode.name{
                     cellNode.addChild(node)
-                    gameBoard.addPlayerValueAtBoardLocation(i, value: gameBoard.isPlayerOne() ? .X : .O)
+                    gameBoard.addPlayerValueAtBoardLocation(i, value: gameBoard.isPlayerOne() ? .x : .o)
                     gameBoard.togglePlayer()
                 }
             }
         }
     }
    
-    override func update(currentTime: CFTimeInterval) {
+    override func update(_ currentTime: TimeInterval) {
         /* Called before each frame is rendered */
-        self.stateMachine.updateWithDeltaTime(currentTime)
+        self.stateMachine.update(deltaTime: currentTime)
     }
 }

--- a/TicTacToe/GameScene.swift
+++ b/TicTacToe/GameScene.swift
@@ -65,7 +65,7 @@ class GameScene: SKScene {
             if gameBoard.isPlayerOne(){
                 let cross = SKSpriteNode(imageNamed: "X_symbol")
                 cross.size = CGSize(width: 75, height: 75)
-                cross.zRotation = CGFloat(M_PI / 4.0)
+                cross.zRotation = CGFloat.pi / 4.0
                 node = cross
             }
             else{
@@ -75,12 +75,12 @@ class GameScene: SKScene {
             }
             
             for i in 0...8{
-                guard let cellNode: SKSpriteNode = self.childNode(withName: gameBoard.getElementAtBoardLocation(i).node) as? SKSpriteNode else{
-                    return
+                guard let cellNode: SKSpriteNode = self.childNode(withName: gameBoard.getElementAtBoardLocation(i)?.node ?? "") as? SKSpriteNode else{
+                    continue
                 }
                 if selectedNode.name == cellNode.name{
                     cellNode.addChild(node)
-                    gameBoard.addPlayerValueAtBoardLocation(i, value: gameBoard.isPlayerOne() ? .x : .o)
+                    _ = gameBoard.addPlayerValueAtBoardLocation(i, value: gameBoard.isPlayerOne() ? .x : .o)
                     gameBoard.togglePlayer()
                 }
             }

--- a/TicTacToe/GameStateMachine.swift
+++ b/TicTacToe/GameStateMachine.swift
@@ -21,40 +21,40 @@ class StartGameState: GKState{
         super.init()
     }
     
-    override func isValidNextState(stateClass: AnyClass) -> Bool {
+    override func isValidNextState(_ stateClass: AnyClass) -> Bool {
         return stateClass == ActiveGameState.self
     }
     
-    override func updateWithDeltaTime(seconds: NSTimeInterval) {
+    override func update(deltaTime seconds: TimeInterval) {
         resetGame()
-        self.stateMachine?.enterState(ActiveGameState.self)
+        self.stateMachine?.enter(ActiveGameState.self)
     }
     
     func resetGame(){
-        let top_left: BoardCell  = BoardCell(value: .None, node: "//*top_left")
-        let top_middle: BoardCell = BoardCell(value: .None, node: "//*top_middle")
-        let top_right: BoardCell = BoardCell(value: .None, node: "//*top_right")
-        let middle_left: BoardCell = BoardCell(value: .None, node: "//*middle_left")
-        let center: BoardCell = BoardCell(value: .None, node: "//*center")
-        let middle_right: BoardCell = BoardCell(value: .None, node: "//*middle_right")
-        let bottom_left: BoardCell = BoardCell(value: .None, node: "//*bottom_left")
-        let bottom_middle: BoardCell = BoardCell(value: .None, node: "//*bottom_middle")
-        let bottom_right: BoardCell = BoardCell(value: .None, node: "//*bottom_right")
+        let top_left: BoardCell  = BoardCell(value: .none, node: "//*top_left")
+        let top_middle: BoardCell = BoardCell(value: .none, node: "//*top_middle")
+        let top_right: BoardCell = BoardCell(value: .none, node: "//*top_right")
+        let middle_left: BoardCell = BoardCell(value: .none, node: "//*middle_left")
+        let center: BoardCell = BoardCell(value: .none, node: "//*center")
+        let middle_right: BoardCell = BoardCell(value: .none, node: "//*middle_right")
+        let bottom_left: BoardCell = BoardCell(value: .none, node: "//*bottom_left")
+        let bottom_middle: BoardCell = BoardCell(value: .none, node: "//*bottom_middle")
+        let bottom_right: BoardCell = BoardCell(value: .none, node: "//*bottom_right")
         
-        boardNode = self.scene?.childNodeWithName("//Grid") as? SKSpriteNode
+        boardNode = self.scene?.childNode(withName: "//Grid") as? SKSpriteNode
         
-        winningLabel = self.scene?.childNodeWithName("winningLabel")
-        winningLabel.hidden = true
+        winningLabel = self.scene?.childNode(withName: "winningLabel")
+        winningLabel.isHidden = true
         
-        resetNode = self.scene?.childNodeWithName("Reset")
-        resetNode.hidden = true
+        resetNode = self.scene?.childNode(withName: "Reset")
+        resetNode.isHidden = true
         
         
         let board = [top_left, top_middle, top_right, middle_left, center, middle_right, bottom_left, bottom_middle, bottom_right]
         
         self.scene?.gameBoard = Board(gameboard: board)
         
-        self.scene?.enumerateChildNodesWithName("//grid*") { (node, stop) in
+        self.scene?.enumerateChildNodes(withName: "//grid*") { (node, stop) in
             if let node = node as? SKSpriteNode{
                 node.removeAllChildren()
             }
@@ -70,17 +70,17 @@ class EndGameState: GKState{
         super.init()
     }
     
-    override func isValidNextState(stateClass: AnyClass) -> Bool {
+    override func isValidNextState(_ stateClass: AnyClass) -> Bool {
         return stateClass == StartGameState.self
     }
     
-    override func didEnterWithPreviousState(previousState: GKState?) {
+    override func didEnter(from previousState: GKState?) {
         updateGameState()
     }
     
     func updateGameState(){
-        let resetNode = self.scene?.childNodeWithName("Reset")
-        resetNode?.hidden = false
+        let resetNode = self.scene?.childNode(withName: "Reset")
+        resetNode?.isHidden = false
     }
 }
 
@@ -94,15 +94,15 @@ class ActiveGameState: GKState{
         super.init()
     }
     
-    override func isValidNextState(stateClass: AnyClass) -> Bool {
+    override func isValidNextState(_ stateClass: AnyClass) -> Bool {
         return stateClass == EndGameState.self
     }
     
-    override func didEnterWithPreviousState(previousState: GKState?) {
+    override func didEnter(from previousState: GKState?) {
         waitingOnPlayer = false
     }
     
-    override func updateWithDeltaTime(seconds: NSTimeInterval) {
+    override func update(deltaTime seconds: TimeInterval) {
         assert(scene != nil, "Scene must not be nil")
         assert(scene?.gameBoard != nil, "Gameboard must not be nil")
         
@@ -117,15 +117,15 @@ class ActiveGameState: GKState{
         assert(scene?.gameBoard != nil, "Gameboard must not be nil")
         
         let (state, winner) = self.scene!.gameBoard!.determineIfWinner()
-        if state == .Winner{
-            let winningLabel = self.scene?.childNodeWithName("winningLabel")
-            winningLabel?.hidden = true
+        if state == .winner{
+            let winningLabel = self.scene?.childNode(withName: "winningLabel")
+            winningLabel?.isHidden = true
             let winningPlayer = self.scene!.gameBoard!.isPlayerOne(winner!) ? "1" : "2"
             if let winningLabel = winningLabel as? SKLabelNode,
-                let player1_score = self.scene?.childNodeWithName("//player1_score") as? SKLabelNode,
-                let player2_score = self.scene?.childNodeWithName("//player2_score") as? SKLabelNode{
+                let player1_score = self.scene?.childNode(withName: "//player1_score") as? SKLabelNode,
+                let player2_score = self.scene?.childNode(withName: "//player2_score") as? SKLabelNode{
                 winningLabel.text = "Player \(winningPlayer) wins!"
-                winningLabel.hidden = false
+                winningLabel.isHidden = false
                 
                 if winningPlayer == "1"{
                     player1_score.text = "\(Int(player1_score.text!)! + 1)"
@@ -134,31 +134,31 @@ class ActiveGameState: GKState{
                     player2_score.text = "\(Int(player2_score.text!)! + 1)"
                 }
                 
-                self.stateMachine?.enterState(EndGameState.self)
+                self.stateMachine?.enter(EndGameState.self)
                 waitingOnPlayer = false
             }
         }
-        else if state == .Draw{
-            let winningLabel = self.scene?.childNodeWithName("winningLabel")
-            winningLabel?.hidden = true
+        else if state == .draw{
+            let winningLabel = self.scene?.childNode(withName: "winningLabel")
+            winningLabel?.isHidden = true
             
             
             if let winningLabel = winningLabel as? SKLabelNode{
                 winningLabel.text = "It's a draw"
-                winningLabel.hidden = false
+                winningLabel.isHidden = false
             }
-            self.stateMachine?.enterState(EndGameState.self)
+            self.stateMachine?.enter(EndGameState.self)
             waitingOnPlayer = false
         }
 
         else if self.scene!.gameBoard!.isPlayerTwoTurn(){
             //AI moves
-            self.scene?.userInteractionEnabled = false
+            self.scene?.isUserInteractionEnabled = false
             
             assert(scene != nil, "Scene must not be nil")
             assert(scene?.gameBoard != nil, "Gameboard must not be nil")
                 
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.default).async {
                 self.scene!.ai.gameModel = self.scene!.gameBoard!
                 let move = self.scene!.ai.bestMoveForActivePlayer() as? Move
                     
@@ -166,27 +166,27 @@ class ActiveGameState: GKState{
                     
                 let strategistTime = CFAbsoluteTimeGetCurrent()
                 let delta = CFAbsoluteTimeGetCurrent() - strategistTime
-                let  aiTimeCeiling: NSTimeInterval = 1.0
+                let  aiTimeCeiling: TimeInterval = 1.0
                     
                 let delay = min(aiTimeCeiling - delta, aiTimeCeiling)
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(delay) * Int64(NSEC_PER_SEC)), dispatch_get_main_queue()) {
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(delay) * Int64(NSEC_PER_SEC)) / Double(NSEC_PER_SEC)) {
                         
-                    guard let cellNode: SKSpriteNode = self.scene?.childNodeWithName(self.scene!.gameBoard!.getElementAtBoardLocation(move!.cell).node) as? SKSpriteNode else{
+                    guard let cellNode: SKSpriteNode = self.scene?.childNode(withName: self.scene!.gameBoard!.getElementAtBoardLocation(move!.cell).node) as? SKSpriteNode else{
                             return
                     }
                     let circle = SKSpriteNode(imageNamed: "O_symbol")
                     circle.size = CGSize(width: 75, height: 75)
                     cellNode.addChild(circle)
-                    self.scene!.gameBoard!.addPlayerValueAtBoardLocation(move!.cell, value: .O)
+                    self.scene!.gameBoard!.addPlayerValueAtBoardLocation(move!.cell, value: .o)
                     self.scene!.gameBoard!.togglePlayer()
                     self.waitingOnPlayer = false
-                    self.scene?.userInteractionEnabled = true
+                    self.scene?.isUserInteractionEnabled = true
                 }
             }
         }
         else{
             self.waitingOnPlayer = false
-            self.scene?.userInteractionEnabled = true
+            self.scene?.isUserInteractionEnabled = true
         }
     }
 }

--- a/TicTacToe/GameViewController.swift
+++ b/TicTacToe/GameViewController.swift
@@ -24,21 +24,21 @@ class GameViewController: UIViewController {
             skView.ignoresSiblingOrder = true
             
             /* Set the scale mode to scale to fit the window */
-            scene.scaleMode = .AspectFill
+            scene.scaleMode = .aspectFill
             
             skView.presentScene(scene)
         }
     }
 
-    override func shouldAutorotate() -> Bool {
+    override var shouldAutorotate : Bool {
         return true
     }
 
-    override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-        if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
-            return .Portrait
+    override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            return .portrait
         } else {
-            return .All
+            return .all
         }
     }
 
@@ -47,7 +47,7 @@ class GameViewController: UIViewController {
         // Release any cached data, images, etc that aren't in use.
     }
 
-    override func prefersStatusBarHidden() -> Bool {
+    override var prefersStatusBarHidden : Bool {
         return true
     }
 }

--- a/TicTacToe/GameViewController.swift
+++ b/TicTacToe/GameViewController.swift
@@ -14,9 +14,9 @@ class GameViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if let scene = GameScene(fileNamed:"GameScene") {
+        if let scene = GameScene(fileNamed:"GameScene"),
+           let skView = self.view as? SKView {
             // Configure the view.
-            let skView = self.view as! SKView
             skView.showsFPS = true
             skView.showsNodeCount = true
             


### PR DESCRIPTION
Minor changes in to Swift 3.0 using Xcode's automatic code conversion.

Deprecated in GameStateMachine.swift:161 
`DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.default).async { ...`
GameStateMachine.swift:161:27: 'global(priority:)' was deprecated in iOS 8.0
GameStateMachine.swift:161:78: 'default' was deprecated in iOS 8.0: Use qos attributes instead

PJN

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrkeithelliott/tictactoe/1)

<!-- Reviewable:end -->
